### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Myip
 
-Publisher: Splunk \
-Connector Version: 2.0.6 \
-Product Vendor: Myip.ms \
-Product Name: Myip.ms \
+Publisher: Splunk <br>
+Connector Version: 2.0.6 <br>
+Product Vendor: Myip.ms <br>
+Product Name: Myip.ms <br>
 Minimum Product Version: 4.9.39220
 
 This app integrates with the Myip.ms service to implement investigative actions
@@ -20,15 +20,15 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
-[whois domain](#action-whois-domain) - Execute whois lookup on the given domain \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
+[whois domain](#action-whois-domain) - Execute whois lookup on the given domain <br>
 [whois ip](#action-whois-ip) - Execute whois lookup on the given IP address
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -43,7 +43,7 @@ No Output
 
 Execute whois lookup on the given domain
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -115,7 +115,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Execute whois lookup on the given IP address
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/myip.json
+++ b/myip.json
@@ -1193,5 +1193,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/myip.json
+++ b/myip.json
@@ -19,7 +19,7 @@
     "latest_tested_versions": [
         "Myip.ms Cloud, 2021 on 01/28/2021"
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "app_wizard_version": "1.0.0",
     "configuration": {
         "base_url": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,8 +1,3 @@
 **Unreleased**
-* Update Python dependencies for vulnerabilities, package updates, and platform built-in removals
-* Update Python dependencies for Python 3.13 support
-* Update NOTICE file with updated dependencies
-* Apply pre-commit fixes
-* Remove beautifulsoup4 from requirements.txt
-* Resolved app issues related to Python 3.13 upgrade
+* Update Python dependencies and code for Python 3.13 support
 * Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)